### PR TITLE
fix: Project.jsのmap()にkeyプロップを追加してReact警告を解消

### DIFF
--- a/src/components/molecules/Project.js
+++ b/src/components/molecules/Project.js
@@ -21,10 +21,10 @@ class Project extends React.Component {
         if (this.props.snsButtonItemDictList.length !== 0) {
             snsButtons = (
                 <div className="sns-buttons">
-                    {this.props.snsButtonItemDictList.map((snsButtonItemDict)=>{
+                    {this.props.snsButtonItemDictList.map((snsButtonItemDict, index)=>{
                         if (snsButtonItemDict['type'] === 'img') {
                             return(
-                                <div>
+                                <div key={index}>
                                     <a href={snsButtonItemDict['url']} target="_blank" rel="noopener noreferrer">
                                         <img className="sns_icon" src={snsButtonItemDict['img']} alt={snsButtonItemDict['alt']}></img>
                                     </a>
@@ -32,7 +32,7 @@ class Project extends React.Component {
                             )
                         } else if (snsButtonItemDict['type'] === 'a') {
                             return(
-                                <div className='button-sns'>
+                                <div key={index} className='button-sns'>
                                     <a href={snsButtonItemDict['url']} target="_blank" rel="noopener noreferrer">
                                         {snsButtonItemDict['text']}
                                     </a>
@@ -54,9 +54,9 @@ class Project extends React.Component {
         if (this.props.awardDictList.length !== 0) {
             awards = (
                 <div>
-                    {this.props.awardDictList.map((awardDict)=>{
+                    {this.props.awardDictList.map((awardDict, index)=>{
                         return(
-                            <div>
+                            <div key={index}>
                                 <h2 className="award-ribbon"><span className='awarded-competition-name'>{awardDict.competitionName}<br/></span>{awardDict.awardTitle}&nbsp;受賞</h2>
                             </div>
                         )
@@ -76,9 +76,9 @@ class Project extends React.Component {
                     <p className="project_name">{this.props.projectName}</p>
                     {competition}
                     {awards}
-                    {this.props.projectDescriptionList.map((projectDescription)=>{
+                    {this.props.projectDescriptionList.map((projectDescription, index)=>{
                         return(
-                            <p className="project_description">&nbsp;&nbsp;{projectDescription}</p>
+                            <p key={index} className="project_description">&nbsp;&nbsp;{projectDescription}</p>
                         )
                     })}
                     {snsButtons}


### PR DESCRIPTION
## Summary

- `Project.js` 内の3箇所の `.map()` 呼び出しで、ルート要素に `key` プロップが未設定だった問題を修正
- `snsButtonItemDictList.map()`、`awardDictList.map()`、`projectDescriptionList.map()` それぞれのルート要素に `key={index}` を追加

## Test plan

- [ ] プロジェクト一覧ページ（`/Projects`）を表示し、各プロジェクトカードが正常に描画されること
- [ ] ブラウザのDevToolsコンソールに「Each child in a list should have a unique "key" prop」の警告が出ないこと
- [ ] SNSボタン・受賞リスト・説明文の表示が変わっていないこと

Close #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)