### PR TITLE
fix: ISUM登録証明書を静的画像からISUM提供の埋め込みウィジェットに変更

### DIFF
--- a/src/components/molecules/IsumCertificate.css
+++ b/src/components/molecules/IsumCertificate.css
@@ -1,21 +1,6 @@
-/* .isum-certificate-box {
-    min-width: 600px;
-    margin: 0 auto;
-}
-
-.isum-certificate {
-    max-height: calc(100vh - 74px - 51px);
-} */
 .isum-certificate-box {
     display: flex;
     justify-content: center;
     align-items: center;
-    height: calc(100vh - 74px - 51px); /* 画面の高さに合わせる */
-  }
-  
-  .isum-certificate-box img {
-    max-width: 100%; /* 画像がコンテナを超えないようにする */
-    height: auto; /* 画像のアスペクト比を維持 */
-    max-height: calc(100vh - 74px - 51px);
-  }
-  
+    min-height: calc(100vh - 74px - 51px);
+}

--- a/src/components/molecules/IsumCertificate.js
+++ b/src/components/molecules/IsumCertificate.js
@@ -3,9 +3,12 @@ import './IsumCertificate.css';
 
 const IsumCertificate = () => {
     useEffect(() => {
+        const SCRIPT_SRC = 'https://isum.or.jp/js/isumCertificate.js';
+        if (document.querySelector(`script[src="${SCRIPT_SRC}"]`)) return;
+
         const script = document.createElement('script');
         script.type = 'text/javascript';
-        script.src = 'https://isum.or.jp/js/isumCertificate.js';
+        script.src = SCRIPT_SRC;
         document.body.appendChild(script);
 
         return () => {

--- a/src/components/molecules/IsumCertificate.js
+++ b/src/components/molecules/IsumCertificate.js
@@ -1,13 +1,24 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import './IsumCertificate.css';
-import IsumCertificateDoc from './img/business/isum_certificate.png'
 
-const ImageView = () => {
+const IsumCertificate = () => {
+    useEffect(() => {
+        const script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.src = 'https://isum.or.jp/js/isumCertificate.js';
+        document.body.appendChild(script);
+
+        return () => {
+            document.body.removeChild(script);
+        };
+    }, []);
+
     return (
         <div className='isum-certificate-box'>
-            <img className="isum-certificate" src={IsumCertificateDoc} alt="The Certificate of ISUM"></img>
+            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+            <a id="isumCertificateBanner" data-text="4965f3c8a488b34">ISUM登録証明書</a>
         </div>
     );
 };
 
-export default ImageView;
+export default IsumCertificate;


### PR DESCRIPTION
## Summary
- ISUMより「画像そのままの貼り付けはお控えください」との要請を受けた (#218)
- `IsumCertificate.js`: 静的 `<img>` 表示を廃止し、ISUM Meleteシステム提供の埋め込みコード（`<a id="isumCertificateBanner">` + 外部JS）を `useEffect` で動的読み込みする実装に変更
- `IsumCertificate.css`: 画像前提のスタイル（`max-height`・`img` セレクタ等）を削除し整理

## Test plan
- [x] `/IsumCertificate` ページにアクセスしてISUM証明書ウィジェットが表示されることを確認
- [x] ページ離脱時にスクリプトが適切にクリーンアップされることを確認
- [x] モバイル・PC両方でレイアウトが崩れていないことを確認

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)