### PR TITLE
fix: _redirectsにIsumCertificateルートを追加

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -2,6 +2,7 @@
 /Members    /index.html   200
 /Projects    /index.html   200
 /Business    /index.html   200
+/IsumCertificate    /index.html   200
 /DigitalHackDay2021    /index.html   200
 /Chiko    /index.html    200
 /Sui    /index.html    200


### PR DESCRIPTION
## Summary
- `public/_redirects` に `/IsumCertificate` エントリが抜けており、catch-all の `/* /index.html 301` にヒットして本番で `/index.html` へリダイレクトされていた問題を修正 (#220)
- 他のルートと同様に `200`（リライト）として追加することでURLを変えずに `index.html` を返すよう修正

## Test plan
- [ ] 本番環境で `https://ushinohi.com/IsumCertificate` に直接アクセスしてURLが変わらずISUM証明書ページが表示されることを確認
- [ ] 他のルート（`/Members`、`/Business` など）が引き続き正常動作することを確認

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)